### PR TITLE
Tests, bug fixes & Bool support

### DIFF
--- a/prototype-ghc-prover.cabal
+++ b/prototype-ghc-prover.cabal
@@ -31,7 +31,7 @@ flag examples
   default: False
   manual: True
 
-common shared
+common common-options
   default-language: GHC2024
   ghc-options: -Wall -Wcompat
   default-extensions:
@@ -45,7 +45,7 @@ common shared
     , base >= 4.20 && < 4.21
 
 library
-  import: shared
+  import: common-options
   hs-source-dirs: src
   exposed-modules:
     GHC.TypeNats.Proof
@@ -70,7 +70,7 @@ library
     , transformers
 
 library examples
-  import: shared
+  import: common-options
   hs-source-dirs: examples
   if !flag(examples)
     buildable: False
@@ -82,3 +82,19 @@ library examples
     Intro
     Intro.CoqProof
     Intro.AgdaProof
+
+test-suite compile
+  import: common-options
+  hs-source-dirs: tests
+  type: exitcode-stdio-1.0
+  ghc-options:
+    -threaded
+    -fplugin=GHC.TypeNats.Proof.Plugin
+    -fplugin-opt=GHC.TypeNats.Proof.Plugin:VerifyProofs=True
+  main-is: Main.hs
+  other-modules:
+    Test.GHC.TypeNats.Proof.Plugin.Agda
+    Test.GHC.TypeNats.Proof.Plugin.Coq
+  build-depends:
+    , base
+    , ghc-typelits-proof-assist

--- a/src/GHC/TypeNats/Proof.hs
+++ b/src/GHC/TypeNats/Proof.hs
@@ -2,9 +2,63 @@
 {- | The 'QED' class and a custom dictionary type to be used to
    interface with the plugin.
 -}
-module GHC.TypeNats.Proof where
+module GHC.TypeNats.Proof
+  ( Rewrite(..)
+  , QED(..)
+    -- * Supported Operators (re-exported)
+  , NonZero
+  , type (<)
+  , type (<=)
+  , type (>)
+  , type (>=)
+  , type (==)
+  , type (<?)
+  , type (<=?)
+  , type (>?)
+  , type (>=?)
+  , type (+)
+  , type (-)
+  , type (*)
+  , type (^)
+  , type (&&)
+  , type (||)
+  , Not
+  , If
+  , Div
+  , Mod
+  , Min
+  , Max
+  , Log
+  , CLog
+  , FLog
+  , Log2
+  , CLog2
+  , FLog2
+  , GCD
+  , LCM
+    -- * Other re-exports
+  , Constraint
+  )
+  where
 
 import Data.Kind (Constraint)
+import Data.Type.Bool (type (&&), type (||), Not, If)
+import Data.Type.Equality (type (==))
+import Data.Type.Ord
+  ( type (<), type (<=), type (>), type (>=)
+  , type (<?), type (<=?), type (>?), type (>=?)
+  )
+import GHC.TypeNats (type (+), type (-), type (*), type (^), Div, Mod, Log2)
+import GHC.TypeLits.Extra (Min, Max, Log, CLog, FLog, GCD, LCM)
+
+-- | Type alias for 'CLog' with base two.
+type CLog2 n = CLog 2 n
+
+-- | Type alias for 'FLog' with base two.
+type FLog2 n = FLog 2 n
+
+-- | Type alias for non-zero number constraints.
+type NonZero n = 1 <= n
 
 -- | The plugin-specific dictionary type, where we offer our own
 -- definition at this point to support availability of the plugin to

--- a/src/GHC/TypeNats/Proof/Plugin/KnownTypes.hs
+++ b/src/GHC/TypeNats/Proof/Plugin/KnownTypes.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE TemplateHaskellQuotes #-}
 module GHC.TypeNats.Proof.Plugin.KnownTypes
-  ( KOp(..)
+  ( type (~>)(..)
   , KnownTypes(..)
   , FromTyCon(..)
   , lookupKnownTypes
   ) where
 
 import GHC.Base (Constraint, Type)
-import GHC.Builtin.Types (eqTyCon, naturalTyCon)
+import GHC.Builtin.Types (eqTyCon)
 import GHC.Builtin.Types.Literals
   ( typeNatAddTyCon, typeNatSubTyCon, typeNatMulTyCon
   , typeNatExpTyCon, typeNatDivTyCon, typeNatModTyCon, typeNatLogTyCon
@@ -23,39 +23,53 @@ import GHC.Types.Unique.FM (listToUFM, lookupUFM)
 import GHC.Utils.Outputable
   (SDoc, Outputable(..), (<+>), braces, pprWithCommas)
 
-import qualified Data.Kind
+import qualified Data.Type.Bool
+import qualified Data.Type.Equality
 import qualified Data.Type.Ord
 import qualified GHC.TypeError
 import qualified GHC.TypeLits.Extra
 import qualified GHC.TypeNats.Proof
 
--- | The known Tynal operator.
-data KOp sig where
-  EqC  :: KOp (Nat -> Nat -> Constraint)
-  LtC  :: KOp (Nat -> Nat -> Constraint)
-  LeC  :: KOp (Nat -> Nat -> Constraint)
-  GtC  :: KOp (Nat -> Nat -> Constraint)
-  GeC  :: KOp (Nat -> Nat -> Constraint)
-  Add  :: KOp (Nat -> Nat -> Nat)
-  Sub  :: KOp (Nat -> Nat -> Nat)
-  Mul  :: KOp (Nat -> Nat -> Nat)
-  Exp  :: KOp (Nat -> Nat -> Nat)
-  Div  :: KOp (Nat -> Nat -> Nat)
-  Mod  :: KOp (Nat -> Nat -> Nat)
-  Log2 :: KOp (Nat -> Nat)
-  Min  :: KOp (Nat -> Nat -> Nat)
-  Max  :: KOp (Nat -> Nat -> Nat)
-  FLog :: KOp (Nat -> Nat -> Nat)
-  CLog :: KOp (Nat -> Nat -> Nat)
-  Log  :: KOp (Nat -> Nat -> Nat)
-  GCD  :: KOp (Nat -> Nat -> Nat)
-  LCM  :: KOp (Nat -> Nat -> Nat)
+-- | The known Tynal operators.
+infixr ~>
+data a ~> b where
+  NZero :: Nat ~> Constraint
+  EqC   :: a ~> a ~> Constraint
+  LtC   :: Nat ~> Nat ~> Constraint
+  LeC   :: Nat ~> Nat ~> Constraint
+  GtC   :: Nat ~> Nat ~> Constraint
+  GeC   :: Nat ~> Nat ~> Constraint
+  EqB   :: a ~> a ~> Bool
+  LtB   :: Nat ~> Nat ~> Bool
+  LeB   :: Nat ~> Nat ~> Bool
+  GtB   :: Nat ~> Nat ~> Bool
+  GeB   :: Nat ~> Nat ~> Bool
+  And   :: Bool ~> Bool ~> Bool
+  Or    :: Bool ~> Bool ~> Bool
+  Not   :: Bool ~> Bool
+  If    :: Bool ~> a ~> a ~> a
+  Add   :: Nat ~> Nat ~> Nat
+  Sub   :: Nat ~> Nat ~> Nat
+  Mul   :: Nat ~> Nat ~> Nat
+  Exp   :: Nat ~> Nat ~> Nat
+  Div   :: Nat ~> Nat ~> Nat
+  Mod   :: Nat ~> Nat ~> Nat
+  Log2  :: Nat ~> Nat
+  CLog2 :: Nat ~> Nat
+  FLog2 :: Nat ~> Nat
+  Min   :: Nat ~> Nat ~> Nat
+  Max   :: Nat ~> Nat ~> Nat
+  Log   :: Nat ~> Nat ~> Nat
+  FLog  :: Nat ~> Nat ~> Nat
+  CLog  :: Nat ~> Nat ~> Nat
+  GCD   :: Nat ~> Nat ~> Nat
+  LCM   :: Nat ~> Nat ~> Nat
 
-deriving stock instance Eq   (KOp sig)
-deriving stock instance Ord  (KOp sig)
-deriving stock instance Show (KOp sig)
+deriving stock instance Eq   (a ~> b)
+deriving stock instance Ord  (a ~> b)
+deriving stock instance Show (a ~> b)
 
-instance Outputable (KOp sig) where
+instance Outputable (a ~> b) where
   ppr = ppr . mkFastString . show
 
 type AllArgsClass :: (Type -> Constraint) -> Type -> Constraint
@@ -64,63 +78,94 @@ type family AllArgsClass c sig where
   AllArgsClass c _        = ()
 
 data KnownTypes = KnownTypes
-  { -- | Data.Constraint.Dict
-    ktConstraint :: TyCon
-  , -- | GHC.Natural.Natural
-    ktNat :: TyCon
-  , -- | GHC.TypeError.Assert
+  { -- | GHC.TypeError.Assert
     ktAssert :: TyCon
   , -- | Data.Type.Ord.OrdCond
     ktOrdCond :: TyCon
   , -- | GHC.TypeNats.Proof
     ktQED :: TyCon
   , -- | known operators
-    kOp :: forall sig. KOp sig -> TyCon
+    kOp :: forall a b. (a ~> b) -> TyCon
   }
 
 instance Outputable KnownTypes where
   ppr KnownTypes{..} =
     ("KnownTypes" <+>) $ braces $ ("" <+>) $ (<+> "") $ pprWithCommas id
-      [ ppr ktConstraint, ppr ktNat, ppr ktAssert, ppr ktOrdCond
-      , pOp EqC,  pOp LtC,  pOp LeC, pOp GtC, pOp GeC,  pOp Add, pOp Sub
-      , pOp Log2, pOp Mul,  pOp Exp, pOp Log, pOp FLog, pOp Div, pOp Mod
-      , pOp Min,  pOp CLog, pOp Max, pOp GCD, pOp LCM
+      [ ppr ktAssert, ppr ktOrdCond, pOp EqC,  pOp LtC,   pOp LeC,  pOp GtC
+      , pOp GeC, pOp EqB, pOp LtB,   pOp LeB,  pOp GtB,   pOp GeB,  pOp NZero
+      , pOp And, pOp Or,  pOp Not,   pOp If,   pOp Add,   pOp Sub,  pOp Log2
+      , pOp Div, pOp Mod, pOp Mul,   pOp Exp,  pOp Min,   pOp Max,  pOp Log
+      , pOp GCD, pOp LCM, pOp FLog,  pOp CLog, pOp FLog2, pOp CLog2
       ]
    where
-    pOp :: forall sig. KOp sig -> SDoc
+    pOp :: forall a b. (a ~> b) -> SDoc
     pOp = ppr . kOp
 
 class FromTyCon a where
-  fromTyCon :: KnownTypes -> TyCon -> Maybe (KOp a)
+  fromTyCon :: KnownTypes -> TyCon -> Maybe a
 
-instance FromTyCon (Nat -> Nat) where
+instance FromTyCon (Nat ~> Constraint) where
   fromTyCon KnownTypes{..} = lookupUFM $ listToUFM $ (\x -> (kOp x, x))
-    <$> [ Log2 ]
+    <$> [ NZero ]
 
-instance FromTyCon (Nat -> Nat -> Constraint) where
+instance FromTyCon (Bool ~> Bool ~> Constraint) where
+  fromTyCon KnownTypes{..} = lookupUFM $ listToUFM $ (\x -> (kOp x, x))
+    <$> [ EqC ]
+
+instance FromTyCon (Nat ~> Nat ~> Constraint) where
   fromTyCon KnownTypes{..} = lookupUFM $ listToUFM $ (\x -> (kOp x, x))
     <$> [ EqC, LtC, LeC, GtC, GeC ]
 
-instance FromTyCon (Nat -> Nat -> Nat) where
+instance FromTyCon (Nat ~> Nat ~> Bool) where
+  fromTyCon KnownTypes{..} = lookupUFM $ listToUFM $ (\x -> (kOp x, x))
+    <$> [ EqB, LtB, LeB, GtB, GeB ]
+
+instance FromTyCon (Bool ~> Bool) where
+  fromTyCon KnownTypes{..} = lookupUFM $ listToUFM $ (\x -> (kOp x, x))
+    <$> [ Not ]
+
+instance FromTyCon (Bool ~> Bool ~> Bool) where
+  fromTyCon KnownTypes{..} = lookupUFM $ listToUFM $ (\x -> (kOp x, x))
+    <$> [ EqB, And, Or ]
+
+instance FromTyCon (Bool ~> a ~> a ~> a) where
+  fromTyCon KnownTypes{..} = lookupUFM $ listToUFM $ (\x -> (kOp x, x))
+    <$> [ If ]
+
+instance FromTyCon (Nat ~> Nat) where
+  fromTyCon KnownTypes{..} = lookupUFM $ listToUFM $ (\x -> (kOp x, x))
+    <$> [ Log2, CLog2, FLog2 ]
+
+instance FromTyCon (Nat ~> Nat ~> Nat) where
   fromTyCon KnownTypes{..} = lookupUFM $ listToUFM $ (\x -> (kOp x, x))
     <$> [ Add, Sub, Mul, Exp, Div, Mod, Min, Max
         , FLog, CLog, Log, GCD, LCM
         ]
 
--- | Retrieves the missing 'TyCon's that are not exposed via the GHC
--- API.
+-- | Retrieves the missing 'TyCon's that are not exposed via the GHC API.
 lookupKnownTypes :: TcM KnownTypes
 lookupKnownTypes = do
-  let ktNat = naturalTyCon
-  ktConstraint <- lkup ''Data.Kind.Constraint
   ktAssert     <- lkup ''GHC.TypeError.Assert
   ktOrdCond    <- lkup ''Data.Type.Ord.OrdCond
   ktQED        <- lkup ''GHC.TypeNats.Proof.QED
+  nZeroTyCon   <- lkup ''GHC.TypeNats.Proof.NonZero
 
-  ltTyCon      <- lkup ''(Data.Type.Ord.<)
-  leTyCon      <- lkup ''(Data.Type.Ord.<=)
-  gtTyCon      <- lkup ''(Data.Type.Ord.>)
-  geTyCon      <- lkup ''(Data.Type.Ord.>=)
+  ltCTyCon     <- lkup ''(Data.Type.Ord.<)
+  leCTyCon     <- lkup ''(Data.Type.Ord.<=)
+  gtCTyCon     <- lkup ''(Data.Type.Ord.>)
+  geCTyCon     <- lkup ''(Data.Type.Ord.>=)
+
+  eqBTyCon     <- lkup ''(Data.Type.Equality.==)
+  ltBTyCon     <- lkup ''(Data.Type.Ord.<?)
+  leBTyCon     <- lkup ''(Data.Type.Ord.<=?)
+  gtBTyCon     <- lkup ''(Data.Type.Ord.>?)
+  geBTyCon     <- lkup ''(Data.Type.Ord.>=?)
+
+  ifTyCon      <- lkup ''Data.Type.Bool.If
+  notTyCon     <- lkup ''Data.Type.Bool.Not
+  andTyCon     <- lkup ''(Data.Type.Bool.&&)
+  orTyCon      <- lkup ''(Data.Type.Bool.||)
+
   minTyCon     <- lkup ''GHC.TypeLits.Extra.Min
   maxTyCon     <- lkup ''GHC.TypeLits.Extra.Max
   logTyCon     <- lkup ''GHC.TypeLits.Extra.Log
@@ -128,16 +173,22 @@ lookupKnownTypes = do
   clogTyCon    <- lkup ''GHC.TypeLits.Extra.CLog
   gcdTyCon     <- lkup ''GHC.TypeLits.Extra.GCD
   lcmTyCon     <- lkup ''GHC.TypeLits.Extra.LCM
+  clog2TyCon   <- lkup ''GHC.TypeNats.Proof.CLog2
+  flog2TyCon   <- lkup ''GHC.TypeNats.Proof.FLog2
   let
-    kOp :: forall sig. KOp sig -> TyCon
+    kOp :: forall a b. a ~> b -> TyCon
     kOp = \case
-      Add  -> typeNatAddTyCon  ;  EqC -> eqTyCon   ;  Log  -> logTyCon
-      Sub  -> typeNatSubTyCon  ;  LtC -> ltTyCon   ;  FLog -> flogTyCon
-      Mul  -> typeNatMulTyCon  ;  LeC -> leTyCon   ;  CLog -> clogTyCon
-      Exp  -> typeNatExpTyCon  ;  GtC -> gtTyCon   ;  GCD  -> gcdTyCon
-      Div  -> typeNatDivTyCon  ;  GeC -> geTyCon   ;  LCM  -> lcmTyCon
-      Mod  -> typeNatModTyCon  ;  Min -> minTyCon  ;
-      Log2 -> typeNatLogTyCon  ;  Max -> maxTyCon  ;
+      Add  -> typeNatAddTyCon  ;  EqC -> eqTyCon   ;  NZero -> nZeroTyCon
+      Sub  -> typeNatSubTyCon  ;  LtC -> ltCTyCon  ;  LCM   -> lcmTyCon
+      Mul  -> typeNatMulTyCon  ;  LeC -> leCTyCon  ;  GCD   -> gcdTyCon
+      Exp  -> typeNatExpTyCon  ;  GtC -> gtCTyCon  ;  CLog  -> clogTyCon
+      Div  -> typeNatDivTyCon  ;  GeC -> geCTyCon  ;  FLog  -> flogTyCon
+      Mod  -> typeNatModTyCon  ;  EqB -> eqBTyCon  ;  CLog2 -> clog2TyCon
+      Log2 -> typeNatLogTyCon  ;  LtB -> ltBTyCon  ;  FLog2 -> flog2TyCon
+      If   -> ifTyCon          ;  LeB -> leBTyCon  ;  Log   -> logTyCon
+      And  -> andTyCon         ;  GtB -> gtBTyCon  ;  Min   -> minTyCon
+      Or   -> orTyCon          ;  GeB -> geBTyCon  ;  Max   -> maxTyCon
+      Not  -> notTyCon
 
   return KnownTypes{..}
  where

--- a/src/GHC/TypeNats/Proof/Plugin/Proof.hs
+++ b/src/GHC/TypeNats/Proof/Plugin/Proof.hs
@@ -105,9 +105,10 @@ hasProof kt ie@InstEnvs{..} proofComment@ProofComment{..} = do
       return Nothing
     [proofInstance@ClsInst{..}] -> do
       let iloc = getSrcSpan proofInstance
+          fromSig = partitionEithers . fmap (fmap specializeTerm . fromType kt)
           (noVs, sig@Signature{..}) = tySignature proofClass proofInstance
-          (noWs, premise) = partitionEithers $ fromType kt <$> sigPremise
-          (noGs, conclusion) = partitionEithers $ fromType kt <$> sigConclusion
+          (noWs, premise) = fromSig sigPremise
+          (noGs, conclusion) = fromSig sigConclusion
           proofSignature = sig
             { sigPremise = premise
             , sigConclusion = conclusion

--- a/src/GHC/TypeNats/Proof/Plugin/Prover.hs
+++ b/src/GHC/TypeNats/Proof/Plugin/Prover.hs
@@ -36,9 +36,11 @@ instance Uniquable Prover where
 instance (IsString s, Monoid s) => ProverConfig Prover s where
   proverName p      | HasCfg c <- hasConfig @s p = proverName c
   operatorImports p | HasCfg c <- hasConfig @s p = operatorImports c
-  printLit p        | HasCfg c <- hasConfig @s p = printLit c
+  printBool p       | HasCfg c <- hasConfig @s p = printBool c
+  printNat p        | HasCfg c <- hasConfig @s p = printNat c
   printVar p        | HasCfg c <- hasConfig @s p = printVar c
   printOp p         | HasCfg c <- hasConfig @s p = printOp c
+  printTerm p t     | HasCfg c <- hasConfig @s p = printTerm c t
   printSignature p  | HasCfg c <- hasConfig @s p = printSignature c
   verify p          | HasCfg c <- hasConfig @s p = verify c
 

--- a/src/GHC/TypeNats/Proof/Plugin/Prover/Agda.hs
+++ b/src/GHC/TypeNats/Proof/Plugin/Prover/Agda.hs
@@ -4,12 +4,14 @@ module GHC.TypeNats.Proof.Plugin.Prover.Agda
 
 import Prelude hiding (unwords)
 
+import Data.Either (partitionEithers)
 import Data.String.Combinators
   ((<+>), parens, colon, punctuate, unwords)
 import Data.String (IsString(..))
 import GHC.Data.FastString (unpackFS)
 import GHC.Plugins (getOccString)
 import GHC.Types.Name (NamedThing(..))
+import GHC.Types.Var (TyVar)
 import System.Directory (findExecutable, withCurrentDirectory)
 import System.Exit (ExitCode(..))
 import System.FilePath ((</>), (<.>))
@@ -25,39 +27,63 @@ instance (IsString s, Monoid s) => ProverConfig Agda s where
   proverName _ = "Agda"
 
   operatorImports _ = \case
-    EqC -> "Agda.Builtin.Equality"  ;  Mod  -> "Data.Nat.Base"
-    LtC -> "Data.Nat.Base"          ;  Min  -> "Data.Nat.Base"
-    LeC -> "Data.Nat.Base"          ;  Max  -> "Data.Nat.Base"
-    GtC -> "Data.Nat.Base"          ;  Log2 -> ""
-    GeC -> "Data.Nat.Base"          ;  FLog -> ""
-    Add -> "Agda.Builtin.Nat"       ;  CLog -> ""
-    Sub -> "Agda.Builtin.Nat"       ;  Log  -> ""
-    Mul -> "Agda.Builtin.Nat"       ;  GCD  -> "Data.Nat.GCD"
-    Exp -> "Data.Nat.Base"          ;  LCM  -> "Data.Nat.LCM"
-    Div -> "Data.Nat.Base"
+    EqC   -> "Agda.Builtin.Equality"  ;  And   -> "Data.Bool.Base hiding (_≤_;_<_)"
+    EqB   -> "Agda.Builtin.Equality"  ;  Not   -> "Data.Bool.Base hiding (_≤_;_<_)"
+    NZero -> "Data.Nat.Base"          ;  Or    -> "Data.Bool.Base hiding (_≤_;_<_)"
+    LtC   -> "Data.Nat.Base"          ;  If    -> "Data.Bool.Base hiding (_≤_;_<_)"
+    LeC   -> "Data.Nat.Base"          ;  Log2  -> "Data.Nat.Logarithm"
+    GtC   -> "Data.Nat.Base"          ;  CLog2 -> "Data.Nat.Logarithm"
+    GeC   -> "Data.Nat.Base"          ;  FLog2 -> "Data.Nat.Logarithm"
+    LtB   -> "Data.Nat.Base"          ;  Add   -> "Agda.Builtin.Nat"
+    LeB   -> "Data.Nat.Base"          ;  Sub   -> "Agda.Builtin.Nat"
+    GtB   -> "Data.Nat.Base"          ;  Mul   -> "Agda.Builtin.Nat"
+    GeB   -> "Data.Nat.Base"          ;  GCD   -> "Data.Nat.GCD"
+    Min   -> "Data.Nat.Base"          ;  LCM   -> "Data.Nat.LCM"
+    Max   -> "Data.Nat.Base"          ;  Log   -> ""
+    Exp   -> "Data.Nat.Base"          ;  CLog  -> ""
+    Div   -> "Data.Nat.Base"          ;  FLog  -> ""
+    Mod   -> "Data.Nat.Base"
 
-  printLit _ = fromString . show
-  printVar _ = fromString . getOccString
   printOp _ = \case
-    EqC -> "≡"    ;  LtC -> "<"    ;  LeC -> "≤"  ;  GtC  -> ">"
-    GeC -> "≥"    ;  Add -> "+"    ;  Sub -> "-"  ;  Log2 -> "NO PRIMITIVE"
-    Mul -> "*"    ;  Exp -> "^"    ;  Div -> "/"  ;  CLog -> "NO PRIMITIVE"
-    Mod -> "%"    ;  Min -> "⊓"    ;  Max -> "⊔"  ;  FLog -> "NO PRIMITIVE"
-    GCD -> "gcd"  ;  LCM -> "lcm"  ;  Log -> "NO PRIMITIVE"
+    EqB -> "≡ᵇ"  ;  LtB -> "<ᵇ"  ;  LeB -> "≤ᵇ"   ;  GtB    -> ""
+    GeB -> ""    ;  EqC -> "≡"   ;  LtC -> "<"    ;  NZero  -> "NonZero"
+    LeC -> "≤"   ;  GtC -> ">"   ;  GeC -> "≥"    ;  Log2   -> "⌊log₂_⌋"
+    Add -> "+"   ;  Sub -> "-"   ;  Mul -> "*"    ;  CLog2  -> "⌈log₂_⌉"
+    Exp -> "^"   ;  Div -> "/"   ;  Mod -> "%"    ;  FLog2  -> "⌊log₂_⌋"
+    Min -> "⊓"   ;  Max -> "⊔"   ;  GCD -> "gcd"  ;  LCM    -> "lcm"
+    And -> "∧"   ;  Or  -> "∨"   ;  Not -> "not"  ;  If     -> "if_then_else_"
+    Log -> "NO PRIMITIVE"  ;  CLog  -> "NO PRIMITIVE"  ;  FLog -> "NO PRIMITIVE"
+
+  printBool _ = \case
+    True  -> "true"
+    False -> "false"
+
+  printTerm p = \case
+    Op GtB `S` t0 `S` t1 -> printTerm p $ Op LtB `S` t1 `S` t0
+    Op GeB `S` t0 `S` t1 -> printTerm p $ Op LeB `S` t1 `S` t0
+    t -> defPrintTerm p t
 
   printSignature p Signature{..} = unwords $
-    [ name, colon , parens (unwords $ vars <> [ colon, "ℕ" ]), "→" ]
-    <> ((<+> "→") . printTerm p <$> sigPremise)
+    [ name, colon , parens (unwords $ vars <> [ colon, "ℕ" ]) ]
+    <> ((".{{_ : NonZero " <>) . (<> "}}") . fromString . getOccString <$> nzs)
+    <> [ "→" ] <> ((<+> "→") . printTerm p <$> premise)
     <> punctuate " ∧" (printTerm p <$> sigConclusion)
    where
+    (nzs, premise) = partitionEithers $ partNZVar <$> sigPremise
     name = fromString $ getOccString $ getName sigClass
     vars = fromString . getOccString <$> sigVars
+
+    partNZVar :: Term a -> Either TyVar (Term a)
+    partNZVar = \case
+      Op NZero `S` Var v -> Left v
+      x -> Right x
 
   verify p dir preamble sig@Signature{..} proof = do
     -- Write the proof to the file
     writeFile (dir </> fileName) $ unlines $
       [ "open import" <+> imp
       | imp <- requiredImports p sig
+      , not $ null imp
       ] <>
       [ ""
       ] <>
@@ -81,9 +107,13 @@ instance (IsString s, Monoid s) => ProverConfig Agda s where
 
 instance ProverFixities Agda where
   bOpFixity _ = \case
-    EqC -> Fixity 4 InfixN Infix   ;  LtC  -> Fixity 4 InfixN Infix
-    LeC -> Fixity 4 InfixN Infix   ;  GtC  -> Fixity 4 InfixN Infix
-    GeC -> Fixity 4 InfixN Infix   ;  Add  -> Fixity 6 InfixL Infix
+    EqB -> Fixity 4 InfixN Infix   ;  LtB  -> Fixity 4 InfixN Infix
+    LeB -> Fixity 4 InfixN Infix   ;  GtB  -> Fixity 4 InfixN Infix
+    GeB -> Fixity 4 InfixN Infix   ;  EqC  -> Fixity 4 InfixN Infix
+    LtC -> Fixity 4 InfixN Infix   ;  LeC  -> Fixity 4 InfixN Infix
+    GtC -> Fixity 4 InfixN Infix   ;  GeC  -> Fixity 4 InfixN Infix
+    And -> Fixity 6 InfixR Infix   ;  Or   -> Fixity 5 InfixR Infix
+    If  -> Fixity 0 InfixN Prefix  ;  Add  -> Fixity 6 InfixL Infix
     Sub -> Fixity 6 InfixL Infix   ;  Mul  -> Fixity 7 InfixL Infix
     Exp -> Fixity 8 InfixR Infix   ;  Div  -> Fixity 7 InfixL Infix
     Mod -> Fixity 7 InfixL Infix   ;  Min  -> Fixity 7 InfixL Infix

--- a/src/GHC/TypeNats/Proof/Plugin/Prover/Tynal.hs
+++ b/src/GHC/TypeNats/Proof/Plugin/Prover/Tynal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DefaultSignatures #-}
 module GHC.TypeNats.Proof.Plugin.Prover.Tynal
   ( Tynal
   , Term(..)
@@ -8,7 +9,8 @@ module GHC.TypeNats.Proof.Plugin.Prover.Tynal
   , ProverFixities(..)
   , ProverConfig(..)
   , FromType(..)
-  , printTerm
+  , specializeTerm
+  , defPrintTerm
   , requiredImports
   , dropTKTypes
   , dropTKVars
@@ -29,16 +31,17 @@ import GHC.Core.InstEnv (ClsInst)
 import GHC.Core.TyCo.Rep (Type(..), TyLit(..), FunTyFlag(..), ForAllTyFlag(..))
 import GHC.Core.Type (isTypeLikeKind, typeKind, mkTyConApp)
 import GHC.Data.FastString (FastString)
+import GHC.Plugins (getOccString)
 import GHC.TypeNats (Nat)
 import GHC.Types.Name (NamedThing(..))
 import GHC.Types.Var (VarBndr(..), TyVar, tyVarKind)
 import GHC.Utils.Outputable
-  (Outputable(..), SDoc, (<+>), (<>), pprWithCommas, parens, colon,  hsep, dot)
+  (Outputable(..), SDoc, (<+>), (<>), pprWithCommas, parens, colon, hsep, dot)
 
 import qualified Data.String.Combinators as S ((<+>), parens)
 
 import GHC.TypeNats.Proof.Plugin.KnownTypes
-  ( KnownTypes(..), KOp(..), fromTyCon
+  ( type (~>)(..), KnownTypes(..), fromTyCon
   )
 
 -- | Tynal, an abbreviation for "type-nat language", is a small DSL
@@ -47,30 +50,43 @@ import GHC.TypeNats.Proof.Plugin.KnownTypes
 -- and the corresponding representation within a proof assistant.
 type Tynal = Term Constraint
 
+-- | Base type classification.
+class BaseType a where
+  printBaseType ::
+    (Monoid s, IsString s, ProverConfig p s) =>
+    p -> a -> s
+
+  showBaseType :: a -> String
+  default showBaseType :: Show a => a -> String
+  showBaseType = show
+
+instance BaseType Bool where printBaseType = printBool
+instance BaseType Nat  where printBaseType = printNat
+
 -- | The context free grammar for describing Tynal terms.
 data Term a where
-  Lit :: Nat -> Term a
+  Lit :: BaseType a => a -> Term a
   Var :: TyVar -> Term a
-  UOp :: KOp (a -> b) -> Term a -> Term b
-  BOp :: KOp (a -> b -> c) -> Term a -> Term b -> Term c
+  Op :: (a ~> b) -> Term (a ~> b)
+  S :: Term (a ~> b) -> Term a -> Term b
 
 instance Outputable (Term a) where
   ppr = \case
-    Lit n -> fromString $ show n
+    Lit n -> fromString $ showBaseType n
     Var v -> ppr v
-    UOp op t0 -> pOp op
-      <+> parens (ppr t0)
-    BOp op t0 t1 -> pOp op
-      <+> parens (ppr t0)
-      <+> parens (ppr t1)
+    Op op -> pprOp op
+    S t0 t1 -> ppr t0 <+> parens (ppr t1)
    where
-    pOp :: forall sig. KOp sig -> SDoc
-    pOp = \case
-      EqC  -> "(~)"   ;  LtC -> "(<)"  ;  LeC -> "(<=)" ;  GtC  -> "(>)"
-      GeC  -> "(>=)"  ;  Add -> "(+)"  ;  Sub -> "(-)"  ;  Log  -> "Log"
-      Mul  -> "(*)"   ;  Exp -> "(^)"  ;  Div -> "(/)"  ;  CLog -> "CLog"
-      Mod  -> "Mod"   ;  Min -> "Min"  ;  Max -> "Max"  ;  FLog -> "FLog"
-      Log2 -> "Log2"  ;  GCD -> "GCD"  ;  LCM -> "LCM"
+    pprOp :: (b ~> c) -> SDoc
+    pprOp = \case
+      NZero -> "(1 <=)"  ;  EqC  -> "(~)"   ;  LtC -> "(<)"    ;  LeC -> "(<=)"
+      GtC   -> "(>)"     ;  GeC  -> "(>=)"  ;  EqB -> "(==)"   ;  LtB -> "(<?)"
+      LeB   -> "(<=?)"   ;  GtB  -> "(>?)"  ;  GeB -> "(>=?)"  ;  And -> "(&&)"
+      Or    -> "(||)"    ;  Not  -> "Not"   ;  If  -> "If"     ;  Add -> "(+)"
+      Sub   -> "(-)"     ;  Mul  -> "(*)"   ;  Exp -> "(^)"    ;  Div -> "(/)"
+      Mod   -> "Mod"     ;  Log2 -> "Log2"  ;  Min -> "Min"    ;  Max -> "Max"
+      CLog2 -> "CLog2"   ;  FLog -> "FLog"  ;  GCD -> "GCD"    ;  LCM -> "LCM"
+      FLog2 -> "FLog2"   ;  CLog -> "CLog"  ;  Log -> "Log"
 
 -- | A generalized interface for signatures of a type level proof.
 data Signature a = Signature
@@ -116,12 +132,27 @@ class ProverFixities p => ProverConfig p s where
   proverName :: p -> s
 
   -- | import requirements
-  operatorImports :: p -> KOp sig -> s
+  operatorImports :: p -> (a ~> b) -> s
 
   -- | print configuration
-  printLit       :: p -> Nat -> s
-  printVar       :: p -> TyVar -> s
-  printOp        :: p -> KOp sig -> s
+  printBool :: p -> Bool -> s
+  default printBool :: IsString s => p -> Bool -> s
+  printBool _ = fromString . show
+
+  printNat :: p -> Nat -> s
+  default printNat :: IsString s => p -> Nat -> s
+  printNat _ = fromString . show
+
+  printVar :: p -> TyVar -> s
+  default printVar :: IsString s => p -> TyVar -> s
+  printVar _ = fromString . getOccString
+
+  printOp :: p -> (a ~> b) -> s
+
+  printTerm :: p -> Term a -> s
+  default printTerm :: (Monoid s, IsString s) => p -> Term a -> s
+  printTerm = defPrintTerm
+
   printSignature :: p -> Signature Tynal -> s
 
   -- | the verification backend
@@ -142,11 +173,64 @@ class ProverFixities p => ProverConfig p s where
 -- | A "sub-class" of 'ProverConfig' that does not require an
 -- additional result type parameter
 class ProverFixities p where
-  bOpFixity :: p -> KOp (a -> b -> c) -> Fixity
+  bOpFixity :: p -> (a ~> b ~> c) -> Fixity
 
 -- | A 'Type' to Tynal term converter.
 class FromType a where
   fromType :: KnownTypes -> Type -> Either Type a
+
+instance FromType (Term Bool) where
+  fromType kt@KnownTypes{..} = \case
+
+    TyVarTy v -> return $ Var v
+    TyConApp tc [] | tc == promotedTrueDataCon  -> return $ Lit True
+    TyConApp tc [] | tc == promotedFalseDataCon -> return $ Lit False
+    TyConApp tc [ty0]
+      | Just (op :: Bool ~> Bool) <- fromTyCon kt tc
+      -> do ty0' <- fromType kt ty0
+            return $ Op op `S` ty0'
+
+    TyConApp tc tys
+      | tc == kOp EqB
+      , [ty0, ty1] <- dropTKTypes tys
+      -- We require equality to either monomorphize to the Nats or
+      -- Bools. While technically being a limitation, we don't really
+      -- loose any expressivity at this point, as the only meaningful
+      -- proofs that don't require monomorphization turn out to be
+      -- reflexivity, associativity, and transitivity, which GHC
+      -- already can deduce on its own.
+      , let natCase = do
+              ty0' <- fromType kt ty0
+              ty1' <- fromType kt ty1
+              return $ Op (EqB :: Nat ~> Nat ~> Bool) `S` ty0' `S` ty1'
+            boolCase = do
+              ty0' <- fromType kt ty0
+              ty1' <- fromType kt ty1
+              return $ Op (EqB :: Bool ~> Bool ~> Bool) `S` ty0' `S` ty1'
+      -> either (const boolCase) return natCase
+
+    TyConApp tc tys
+      | Just (op :: Nat ~> Nat ~> Bool) <- fromTyCon kt tc
+      , [ty0, ty1] <- dropTKTypes tys
+      -> do ty0' <- fromType kt ty0
+            ty1' <- fromType kt ty1
+            return $ Op op `S` ty0' `S` ty1'
+
+    TyConApp tc tys
+      | Just (op :: Bool ~> Bool ~> Bool) <- fromTyCon kt tc
+      , [ty0, ty1] <- dropTKTypes tys
+      -> do ty0' <- fromType kt ty0
+            ty1' <- fromType kt ty1
+            return $ Op op `S` ty0' `S` ty1'
+
+    TyConApp tc tys
+      | Just (op :: Bool ~> Bool ~> Bool ~> Bool) <- fromTyCon kt tc
+      , [ty0, ty1, ty2] <- dropTKTypes tys
+      -> do ty0' <- fromType kt ty0
+            ty1' <- fromType kt ty1
+            ty2' <- fromType kt ty2
+            return $ Op op `S` ty0' `S` ty1' `S` ty2'
+    ty -> Left ty
 
 instance FromType (Term Nat) where
   fromType kt = \case
@@ -155,24 +239,57 @@ instance FromType (Term Nat) where
       NumTyLit n -> return $ Lit $ fromInteger n
       _ -> Left $ LitTy lit
     TyConApp tc [ty0]
-      | Just op <- fromTyCon kt tc
+      | Just (op :: Nat ~> Nat) <- fromTyCon kt tc
       -> do ty0' <- fromType kt ty0
-            return $ UOp (op :: KOp (Nat -> Nat)) ty0'
+            return $ Op op `S` ty0'
     TyConApp tc [ty0, ty1]
-      | Just op <- fromTyCon kt tc
+      | Just (op :: Nat ~> Nat ~> Nat) <- fromTyCon kt tc
       -> do ty0' <- fromType kt ty0
             ty1' <- fromType kt ty1
-            return $ BOp (op :: KOp (Nat -> Nat -> Nat)) ty0' ty1'
+            return $ Op op `S` ty0' `S` ty1'
+    TyConApp tc tys
+      | Just (op :: Bool ~> Nat ~> Nat ~> Nat) <- fromTyCon kt tc
+      , [ty0, ty1, ty2] <- dropTKTypes tys
+      -> do ty0' <- fromType kt ty0
+            ty1' <- fromType kt ty1
+            ty2' <- fromType kt ty2
+            return $ Op op `S` ty0' `S` ty1' `S` ty2'
     ty -> Left ty
 
 instance FromType (Term Constraint) where
   fromType kt@KnownTypes{..} = \case
     TyConApp tc tys
-      | Just op <- fromTyCon kt tc
+      | Just (op :: Nat ~> Constraint) <- fromTyCon kt tc
+      , [ty0] <- dropTKTypes tys
+      -> do ty0' <- fromType kt ty0
+            return $ Op op `S` ty0'
+
+    TyConApp tc tys
+      | tc == kOp EqC
+      , [ty0, ty1] <- dropTKTypes tys
+      -- We require equality to either monomorphize to the Nats or
+      -- Bools. While technically being a limitation, we don't really
+      -- loose any expressivity at this point, as the only meaningful
+      -- proofs that don't require monomorphization turn out to be
+      -- reflexivity, associativity, and transitivity, which GHC
+      -- already can deduce on its own.
+      , let natCase = do
+              ty0' <- fromType kt ty0
+              ty1' <- fromType kt ty1
+              return $ Op (EqC :: Nat ~> Nat ~> Constraint) `S` ty0' `S` ty1'
+            boolCase = do
+              ty0' <- fromType kt ty0
+              ty1' <- fromType kt ty1
+              return $ Op (EqC :: Bool ~> Bool ~> Constraint) `S` ty0' `S` ty1'
+      -> either (const boolCase) return natCase
+
+    TyConApp tc tys
+      | Just (op :: Nat ~> Nat ~> Constraint) <- fromTyCon kt tc
       , [ty0, ty1] <- dropTKTypes tys
       -> do ty0' <- fromType kt ty0
             ty1' <- fromType kt ty1
-            return $ BOp (op :: KOp (Nat -> Nat -> Constraint)) ty0' ty1'
+            return $ Op op `S` ty0' `S` ty1'
+
     TyConApp tcAssert [ty, _]
       | tcAssert == ktAssert
       , TyConApp tcOrdCond tys <- ty
@@ -193,40 +310,51 @@ instance FromType (Term Constraint) where
            ]
       -> do ty0' <- fromType kt ty0
             ty1' <- fromType kt ty1
-            return $ BOp (op :: KOp (Nat -> Nat -> Constraint)) ty0' ty1'
+            return $ Op (op :: Nat ~> Nat ~> Constraint) `S` ty0' `S` ty1'
+
     ty -> Left ty
 
--- | Tynal term printer.
-printTerm ::
-  forall p e s.
+-- | Rewrites some special cases.
+specializeTerm :: Term a -> Term a
+specializeTerm = \case
+  Op LeC  `S` (Lit 1) `S` t -> Op NZero `S` specializeTerm t
+  Op CLog `S` (Lit 2) `S` t -> Op CLog2 `S` specializeTerm t
+  Op FLog `S` (Lit 2) `S` t -> Op FLog2 `S` specializeTerm t
+  Op op `S` t -> Op op `S` specializeTerm t
+  t0 `S` t1 -> specializeTerm t0 `S` specializeTerm t1
+  x -> x
+
+defPrintTerm ::
+  forall p s a.
   (Monoid s, IsString s, ProverConfig p s) =>
-  p -> Term e -> s
-printTerm p = \case
-  Lit x -> printLit p x
-  Var n -> printVar p n
-  UOp op t -> printOp p op S.<+> par (printTerm p t)
+  p -> Term a -> s
+defPrintTerm p = \case
+  -- ternary operators
+  Op op `S` t0 `S` t1 `S` t2 -> pOp S.<+> pr t0 S.<+> pr t1 S.<+> pr t2
    where
-    par = case t of
-      Lit{} -> id
-      Var{} -> id
-      _     -> S.parens
-  BOp op t0 t1 -> case pPrefix of
-    Prefix -> pOp S.<+> fT0 S.<+> fT1
-    Infix  -> fT0 S.<+> pOp S.<+> fT1
+    pOp = printOp p op
+
+    pr :: Term u -> s
+    pr t = par t $ printTerm p t
+
+    par :: Term u -> s -> s
+    par = \case { Lit{} -> id ; Var{} -> id ; _ -> S.parens }
+
+  -- binary operators
+  Op op `S` t0 `S` t1 -> case pPrefix of
+    Prefix -> pOp S.<+> pr InfixL t0 S.<+> pr InfixR t1
+    Infix  -> pr InfixL t0 S.<+> pOp S.<+> pr InfixR t1
    where
     Fixity level fixity pPrefix = bOpFixity p op
-
     pOp = printOp p op
-    fT0 = par InfixL t0 pT0
-    fT1 = par InfixR t1 pT1
 
-    pT0 = printTerm p t0
-    pT1 = printTerm p t1
+    pr :: FixityDirection -> Term u -> s
+    pr fx t = par fx t $ printTerm p t
 
-    par :: forall e'. FixityDirection -> Term e' -> s -> s
+    par :: FixityDirection -> Term u -> s -> s
     par fx = \case
-      Lit{} -> id  ;  Var{} -> id  ;  UOp{} -> id
-      BOp op' _ _ -> case pPrefix' of
+      Op _ `S` _ `S` _ `S` _ -> S.parens
+      Op op' `S` _ `S` _ -> case pPrefix' of
         Prefix                 -> S.parens
         Infix | level' < level -> S.parens
               | level' > level -> id
@@ -234,6 +362,21 @@ printTerm p = \case
               | otherwise      -> S.parens
        where
         Fixity level' _ pPrefix' = bOpFixity p op'
+      _ -> id
+
+  -- unary operators
+  Op op `S` t0 -> printOp p op S.<+> par (printTerm p t0)
+   where
+    par = case t0 of
+      Lit{} -> id
+      Var{} -> id
+      _     -> S.parens
+
+  Op op -> printOp p op
+
+  t0 `S` t1 -> printTerm p t0 S.<+> S.parens (printTerm p t1)
+  Lit x -> printBaseType p x
+  Var n -> printVar p n
 
 -- | Extract the required imports from a Tynal term.
 requiredImports ::
@@ -244,9 +387,8 @@ requiredImports p Signature{..} =
  where
   imports :: forall a. Set s -> Term a -> Set s
   imports a = \case
-    UOp op t0 -> imports (insert (operatorImports p op) a) t0
-    BOp op t0 t1 ->
-      imports (imports (insert (operatorImports p op) a) t0) t1
+    Op op -> insert (operatorImports p op) a
+    S t0 t1 -> imports (imports a t0) t1
     _ -> a
 
 -- | Drops the types that are of a TYPE like kind.

--- a/tests/Test/GHC/TypeNats/Proof/Plugin/Agda.hs
+++ b/tests/Test/GHC/TypeNats/Proof/Plugin/Agda.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+module Test.GHC.TypeNats.Proof.Plugin.Agda where
+
+import GHC.TypeNats.Proof
+
+{-/ Preamble (Agda):
+open import Relation.Binary.PropositionalEquality.Core
+open import Data.Nat.Properties
+open import Data.Nat.Base
+open import Data.Nat.DivMod
+/-}
+
+instance T0 n
+class
+  ( 2 * n ~ n + n
+  ) => T0 n
+{-/ Proof (Agda): T0
+T0 zero = refl
+T0 (suc n) = cong suc (cong (n +_) (cong suc (+-comm n zero)))
+/-}
+instance T0 n => QED (T0 n)
+
+instance T1 n
+class
+  ( 2 * n - n ~ n
+  ) => T1 n
+{-/ Proof (Agda): T1
+T1 n
+  rewrite +-comm n zero
+  rewrite +-∸-comm {n} n {n} ≤-refl
+  rewrite n∸n≡0 n
+  = refl
+/-}
+instance T1 n => QED (T1 n)
+
+instance T2 n
+class
+  ( n `Div` 2 <= n
+  ) => T2 n
+{-/ Proof (Agda): T2
+T2 n = m/n≤m n 2
+/-}
+instance T2 n => QED (T2 n)
+
+instance T3 n
+class
+  ( n `Mod` 2 < 2
+  ) => T3 n
+{-/ Proof (Agda): T3
+T3 n = m%n<n n 2
+/-}
+instance T3 n => QED (T3 n)
+
+instance T4 n
+class
+  ( 2 ^ n > 0
+  ) => T4 n
+{-/ Proof (Agda): T4
+T4 n = m^n>0 2 n
+/-}
+instance T4 n => QED (T4 n)
+
+instance
+  ( m >= n
+  ) => T5 m n
+class
+  ( Max m n ~ m
+  ) => T5 m n
+{-/ Proof (Agda): T5
+T5 m n = m≥n⇒m⊔n≡m {m} {n}
+/-}
+instance T5 m n => QED (T5 m n)
+
+instance
+  ( m <= n
+  ) => T6 m n
+class
+  ( Min m n ~ m
+  ) => T6 m n
+{-/ Proof (Agda): T6
+T6 m n = m≤n⇒m⊓n≡m {m} {n}
+/-}
+instance T6 m n => QED (T6 m n)
+
+instance T7 m n
+class
+  ( GCD (2 * m) (2 * n) `Div` 2 ~ GCD m n
+  ) => T7 m n
+{-/ Proof (Agda): T7
+T7 m n = gcd[cm,cn]/c≡gcd[m,n] 2 m n
+/-}
+instance T7 m n => QED (T7 m n)
+
+instance T8 m n
+class
+  ( GCD m n * LCM m n ~ m * n
+  ) => T8 m n
+{-/ Proof (Agda): T8
+T8 = gcd*lcm
+/-}
+instance T8 m n => QED (T8 m n)
+
+instance T9 n
+class
+  ( Log2 (2 ^ n) ~ n
+  ) => T9 n
+{-/ Proof (Agda): T9
+T9 = ⌊log₂[2^n]⌋≡n
+/-}
+instance T9 n => QED (T9 n)
+
+instance T10 n
+class
+  ( FLog2 (2 ^ n) ~ n
+  ) => T10 n
+{-/ Proof (Agda): T10
+T10 = ⌊log₂[2^n]⌋≡n
+/-}
+instance T10 n => QED (T10 n)
+
+instance T11 n
+class
+  ( FLog 2 (2 ^ n) ~ n
+  ) => T11 n
+{-/ Proof (Agda): T11
+T11 = ⌊log₂[2^n]⌋≡n
+/-}
+instance T11 n => QED (T11 n)
+
+instance T12 n
+class
+  ( CLog2 (2 ^ n) ~ n
+  ) => T12 n
+{-/ Proof (Agda): T12
+T12 = ⌈log₂2^n⌉≡n
+/-}
+instance T12 n => QED (T12 n)
+
+instance T13 n
+class
+  ( CLog 2 (2 ^ n) ~ n
+  ) => T13 n
+{-/ Proof (Agda): T13
+T13 = ⌈log₂2^n⌉≡n
+/-}
+instance T13 n => QED (T13 n)
+
+instance
+  ( 1 <= n
+  ) => T14 n
+class
+  ( 0 `Mod` n ~ 0
+  ) => T14 n
+{-/ Proof (Agda): T14
+T14 (suc _) = refl
+/-}
+instance T14 n => QED (T14 n)
+
+instance
+  ( 1 <= n
+  ) => T15 n
+class
+  ( If ((False && True) || Not False) (0 `Mod` n) 3 ~ 0
+  ) => T15 n
+{-/ Proof (Agda): T15
+T15 (suc _) = refl
+/-}
+instance T15 n => QED (T15 n)

--- a/tests/Test/GHC/TypeNats/Proof/Plugin/Coq.hs
+++ b/tests/Test/GHC/TypeNats/Proof/Plugin/Coq.hs
@@ -1,0 +1,194 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+module Test.GHC.TypeNats.Proof.Plugin.Coq where
+
+import GHC.TypeNats.Proof
+
+{-/ Preamble (Coq):
+Require Import Coq.Arith.PeanoNat.
+/-}
+
+instance T0 n
+class
+  ( 2 * n ~ n + n
+  ) => T0 n
+{-/ Proof (Coq): T0
+  intros n.
+  destruct n.
+  reflexivity.
+  rewrite !Nat.mul_succ_l.
+  rewrite Nat.mul_0_l.
+  rewrite Nat.add_0_l.
+  reflexivity.
+/-}
+instance T0 n => QED (T0 n)
+
+instance T1 n
+class
+  ( 2 * n - n ~ n
+  ) => T1 n
+{-/ Proof (Coq): T1
+  intros.
+  rewrite !Nat.mul_succ_l.
+  apply Nat.add_sub.
+/-}
+instance T1 n => QED (T1 n)
+
+instance T2 n
+class
+  ( n `Div` 2 <= n
+  ) => T2 n
+{-/ Proof (Coq): T2
+  intros.
+  apply Nat.Div0.div_le_upper_bound.
+  rewrite !Nat.mul_succ_l.
+  apply Nat.le_add_l.
+/-}
+instance T2 n => QED (T2 n)
+
+instance T3 n
+class
+  ( n `Mod` 2 < 2
+  ) => T3 n
+{-/ Proof (Coq): T3
+  intros.
+  apply Nat.mod_upper_bound.
+  apply Nat.neq_succ_0.
+/-}
+instance T3 n => QED (T3 n)
+
+instance T4 n
+class
+  ( 2 ^ n > 0
+  ) => T4 n
+{-/ Proof (Coq): T4
+  intros.
+  induction n as [| n IH].
+  - simpl. apply Nat.lt_0_1.
+  - rewrite Nat.pow_succ_r. rewrite !Nat.mul_succ_l.
+    simpl.
+    apply Nat.add_pos_pos.
+    apply IH. apply IH.
+    apply Nat.le_0_l.
+/-}
+instance T4 n => QED (T4 n)
+
+instance
+  ( m >= n
+  ) => T5 m n
+class
+  ( Max m n ~ m
+  ) => T5 m n
+{-/ Proof (Coq): T5
+  intros.
+  apply Nat.max_l.
+  apply H.
+/-}
+instance T5 m n => QED (T5 m n)
+
+instance
+  ( m <= n
+  ) => T6 m n
+class
+  ( Min m n ~ m
+  ) => T6 m n
+{-/ Proof (Coq): T6
+  intros.
+  apply Nat.min_l.
+  apply H.
+/-}
+instance T6 m n => QED (T6 m n)
+
+instance T7 m n
+class
+  ( GCD (2 * m) (2 * n) `Div` 2 ~ GCD m n
+  ) => T7 m n
+{-/ Proof (Coq): T7
+  intros.
+  rewrite Nat.gcd_mul_mono_l.
+  rewrite Nat.mul_comm.
+  rewrite Nat.div_mul.
+  reflexivity.
+  apply Nat.neq_succ_0.
+/-}
+instance T7 m n => QED (T7 m n)
+
+instance T8 m n
+class
+  ( LCM (2 * m) (2 * n) ~ 2 * LCM m n
+  ) => T8 m n
+{-/ Proof (Coq): T8
+  intros.
+  apply Nat.lcm_mul_mono_l.
+/-}
+instance T8 m n => QED (T8 m n)
+
+instance T9 n
+class
+  ( Log2 (2 ^ n) ~ n
+  ) => T9 n
+{-/ Proof (Coq): T9
+  intros.
+  apply Nat.log2_pow2.
+  apply Nat.le_0_l.
+/-}
+instance T9 n => QED (T9 n)
+
+instance T10 n
+class
+  ( FLog2 (2 ^ n) ~ n
+  ) => T10 n
+{-/ Proof (Coq): T10
+  intros.
+  apply Nat.log2_pow2.
+  apply Nat.le_0_l.
+/-}
+instance T10 n => QED (T10 n)
+
+instance T11 n
+class
+  ( FLog 2 (2 ^ n) ~ n
+  ) => T11 n
+{-/ Proof (Coq): T11
+  intros.
+  apply Nat.log2_pow2.
+  apply Nat.le_0_l.
+/-}
+instance T11 n => QED (T11 n)
+
+instance
+  ( 1 <= n
+  ) => T12 n
+class
+  ( 0 `Mod` n ~ 0
+  ) => T12 n
+{-/ Proof (Coq): T12
+  intros.
+  apply Nat.Div0.mod_0_l.
+/-}
+instance T12 n => QED (T12 n)
+
+instance
+  ( 1 <= n
+  ) => T13 n
+class
+  ( If ((False && True) || Not False) (0 `Mod` n) 3 ~ 0
+  ) => T13 n
+{-/ Proof (Coq): T13
+  intros.
+  apply Nat.Div0.mod_0_l.
+/-}
+instance T13 n => QED (T13 n)
+
+instance
+  ( a <= b, b <= c
+  ) => T14 a b c
+class
+  ( a <= c
+  ) => T14 a b c
+{-/ Proof (Coq): T14
+  intros a b c H0 H1.
+  apply (Nat.le_trans a b c H0 H1).
+/-}
+instance T14 a b c => QED (T14 a b c)


### PR DESCRIPTION
The PR introduces the following updates:

* Add CLog2 & NonZero support 
* Use `NonZero` assumption for `Div` and `Mod` in Agda
* Add simple compilation tests
* Add Bool support

---

Approved for public release. This work has been supported by funding from the _Agentur für Innovation in der Cybersicherheit GmbH ([Cyberagentur](https://www.cyberagentur.de))_ as part of the [Clash Formal](https://clash-formal.org) project.