### PR TITLE
bump ghc-tcplugin-api to 0.18 for compatibility with natnormalise

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,30 +10,41 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        lib = import ./nix/lib.nix { inherit pkgs; };
 
         ghcVersions = [ "ghc910" "ghc9121" ];
         defaultGhcVersion = "ghc910";
 
         makeOverlay = compilerVersion:
           let
-            overrideFile = ./. + "/nix/override-${compilerVersion}.nix";
+            hsPkgs = pkgs.haskell.packages.${compilerVersion};
 
-            overrides =
-              if builtins.pathExists overrideFile then
-                import overrideFile { inherit pkgs; }
+            ghc-tcplugin-api =
+              lib.callHackageRevision hsPkgs {
+                pkg = "ghc-tcplugin-api";
+                ver = "0.18.1.0";
+                revision = "0";
+                sha256 = "sha256-VE1IDANndcIswnmdgkEwYIqdnFIhwqe12hDPxpLpSQo=";
+                editedCabalFile = "sha256-KJ2NO27XM6kzqlGNSD3V+76WQg452ppYhidXpvqkdso=";
+              };
+
+            overrides = _: _: {
+              inherit ghc-tcplugin-api;
+            };
+
+            ghcOverrideFile = ./. + "/nix/override-${compilerVersion}.nix";
+
+            ghcOverrides =
+              if builtins.pathExists ghcOverrideFile then
+                import ghcOverrideFile { inherit pkgs lib; }
               else
                 f: p: { };
-
-            hsOverlay =
-              pkgs.haskell.packages.${compilerVersion}.override {
-                inherit overrides;
-              };
 
             pkgSrcOverrides = pkgs.haskell.lib.compose.packageSourceOverrides {
               ghc-typelits-proof-assist = ./.;
             };
           in
-            hsOverlay.extend pkgSrcOverrides;
+            ((hsPkgs.extend overrides).extend ghcOverrides).extend pkgSrcOverrides;
 
         overlays = nixpkgs.lib.attrsets.genAttrs ghcVersions makeOverlay;
 
@@ -57,6 +68,7 @@
 
         shells = pkgs.lib.attrsets.genAttrs ghcVersions makeDevShell;
       in {
+        x = overlays;
         devShells = shells // { default = shells.${defaultGhcVersion}; };
       });
 }

--- a/ghc-typelits-proof-assist.cabal
+++ b/ghc-typelits-proof-assist.cabal
@@ -68,7 +68,7 @@ library
     , filepath
     , ghc >= 9.10 && < 9.14
     , ghc-typelits-extra
-    , ghc-tcplugin-api
+    , ghc-tcplugin-api >= 0.18 && < 0.19
     , process
     , string-combinators
     , transformers

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,0 +1,20 @@
+{ pkgs }:
+let
+  inherit (pkgs.haskell.lib) dontCheck dontBenchmark;
+
+  callHackageRevision = oldpkgs: args:
+    let orev = drv: {
+          revision = args.revision;
+          editedCabalFile = args.editedCabalFile;
+        };
+        meta = oldpkgs.callHackageDirect {
+          pkg = args.pkg;
+          ver = args.ver;
+          sha256 = args.sha256;
+        } {};
+     in dontCheck (dontBenchmark (
+          pkgs.haskell.lib.compose.overrideCabal orev meta
+        ));
+in {
+  inherit callHackageRevision;
+}

--- a/nix/override-ghc9121.nix
+++ b/nix/override-ghc9121.nix
@@ -1,5 +1,6 @@
-{ pkgs }:
+{ pkgs, lib }:
 let
+  inherit (lib) callHackageRevision;
   inherit (pkgs.haskell.lib) dontCheck dontBenchmark;
 
   cabalSrc = pkgs.fetchFromGitHub {
@@ -32,20 +33,6 @@ let
     rev    = "5b257704f21110fb5f1faa32a679025966144635";
     sha256 = "sha256-puyzSyfhXA5ICdoC3NeiPpQqCKdw+Nb4I+IFRcUoPnM=";
   };
-
-  callHackageRevision = oldpkgs: args:
-    let orev = drv: {
-          revision = args.revision;
-          editedCabalFile = args.editedCabalFile;
-        };
-        meta = oldpkgs.callHackageDirect {
-          pkg = args.pkg;
-          ver = args.ver;
-          sha256 = args.sha256;
-        } {};
-     in dontCheck (dontBenchmark (
-          pkgs.haskell.lib.compose.overrideCabal orev meta
-        ));
 
   fromCabalSources = oldpkgs: pkg: dontCheck ( dontBenchmark (
     oldpkgs.callCabal2nix pkg (cabalSrc + "/" + pkg) {}


### PR DESCRIPTION
Update the version of `ghc-tcplugin-api` to `0.18.1.0` to fit with the accepted range `>= 0.18 && < 0.19` of recent `natnormalise` versions.

---

Approved for public release. This work has been supported by funding from the _Agentur für Innovation in der Cybersicherheit GmbH ([Cyberagentur](https://www.cyberagentur.de))_ as part of the [Clash Formal](https://clash-formal.org) project.