### PR TITLE
Add CLogWZ support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768875095,
-        "narHash": "sha256-dYP3DjiL7oIiiq3H65tGIXXIT1Waiadmv93JS0sS+8A=",
+        "lastModified": 1770537093,
+        "narHash": "sha256-pF1quXG5wsgtyuPOHcLfYg/ft/QMr8NnX0i6tW2187s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ed142ab1b3a092c4d149245d0c4126a5d7ea00b0",
+        "rev": "fef9403a3e4d31b0a23f0bacebbec52c248fbb51",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,19 +19,6 @@
           let
             hsPkgs = pkgs.haskell.packages.${compilerVersion};
 
-            ghc-tcplugin-api =
-              lib.callHackageRevision hsPkgs {
-                pkg = "ghc-tcplugin-api";
-                ver = "0.18.2.0";
-                revision = "0";
-                sha256 = "sha256-xyXN5AzcE8jAcZ8bN0RGfw65HgNVTrEOLkqV4uiW3PA=";
-                editedCabalFile = "sha256-EmsLFtVrXss7Wj3XThWBYZIIYE2J248JvBvbqVoIuPI=";
-              };
-
-            overrides = _: _: {
-              inherit ghc-tcplugin-api;
-            };
-
             ghcOverrideFile = ./. + "/nix/override-${compilerVersion}.nix";
 
             ghcOverrides =
@@ -44,7 +31,7 @@
               ghc-typelits-proof-assist = ./.;
             };
           in
-            ((hsPkgs.extend overrides).extend ghcOverrides).extend pkgSrcOverrides;
+            (hsPkgs.extend ghcOverrides).extend pkgSrcOverrides;
 
         overlays = nixpkgs.lib.attrsets.genAttrs ghcVersions makeOverlay;
 

--- a/ghc-typelits-proof-assist.cabal
+++ b/ghc-typelits-proof-assist.cabal
@@ -67,7 +67,7 @@ library
     , directory
     , filepath
     , ghc >= 9.10 && < 9.14
-    , ghc-typelits-extra
+    , ghc-typelits-extra >= 0.5.2 && < 0.6
     , ghc-tcplugin-api >= 0.18 && < 0.19
     , process
     , string-combinators

--- a/src/GHC/TypeNats/Proof.hs
+++ b/src/GHC/TypeNats/Proof.hs
@@ -32,6 +32,7 @@ module GHC.TypeNats.Proof
   , Max
   , Log
   , CLog
+  , CLogWZ
   , FLog
   , Log2
   , CLog2
@@ -51,7 +52,7 @@ import Data.Type.Ord
   , type (<?), type (<=?), type (>?), type (>=?)
   )
 import GHC.TypeNats (type (+), type (-), type (*), type (^), Div, Mod, Log2)
-import GHC.TypeLits.Extra (Min, Max, Log, CLog, FLog, GCD, LCM)
+import GHC.TypeLits.Extra (Min, Max, Log, CLog, CLogWZ, FLog, GCD, LCM)
 
 -- | Type alias for 'CLog' with base two.
 type CLog2 n = CLog 2 n

--- a/src/GHC/TypeNats/Proof/Plugin/KnownTypes.hs
+++ b/src/GHC/TypeNats/Proof/Plugin/KnownTypes.hs
@@ -33,37 +33,38 @@ import qualified GHC.TypeNats.Proof
 -- | The known Tynal operators.
 infixr ~>
 data a ~> b where
-  NZero :: Nat ~> Constraint
-  EqC   :: a ~> a ~> Constraint
-  LtC   :: Nat ~> Nat ~> Constraint
-  LeC   :: Nat ~> Nat ~> Constraint
-  GtC   :: Nat ~> Nat ~> Constraint
-  GeC   :: Nat ~> Nat ~> Constraint
-  EqB   :: a ~> a ~> Bool
-  LtB   :: Nat ~> Nat ~> Bool
-  LeB   :: Nat ~> Nat ~> Bool
-  GtB   :: Nat ~> Nat ~> Bool
-  GeB   :: Nat ~> Nat ~> Bool
-  And   :: Bool ~> Bool ~> Bool
-  Or    :: Bool ~> Bool ~> Bool
-  Not   :: Bool ~> Bool
-  If    :: Bool ~> a ~> a ~> a
-  Add   :: Nat ~> Nat ~> Nat
-  Sub   :: Nat ~> Nat ~> Nat
-  Mul   :: Nat ~> Nat ~> Nat
-  Exp   :: Nat ~> Nat ~> Nat
-  Div   :: Nat ~> Nat ~> Nat
-  Mod   :: Nat ~> Nat ~> Nat
-  Log2  :: Nat ~> Nat
-  CLog2 :: Nat ~> Nat
-  FLog2 :: Nat ~> Nat
-  Min   :: Nat ~> Nat ~> Nat
-  Max   :: Nat ~> Nat ~> Nat
-  Log   :: Nat ~> Nat ~> Nat
-  FLog  :: Nat ~> Nat ~> Nat
-  CLog  :: Nat ~> Nat ~> Nat
-  GCD   :: Nat ~> Nat ~> Nat
-  LCM   :: Nat ~> Nat ~> Nat
+  NZero  :: Nat ~> Constraint
+  EqC    :: a ~> a ~> Constraint
+  LtC    :: Nat ~> Nat ~> Constraint
+  LeC    :: Nat ~> Nat ~> Constraint
+  GtC    :: Nat ~> Nat ~> Constraint
+  GeC    :: Nat ~> Nat ~> Constraint
+  EqB    :: a ~> a ~> Bool
+  LtB    :: Nat ~> Nat ~> Bool
+  LeB    :: Nat ~> Nat ~> Bool
+  GtB    :: Nat ~> Nat ~> Bool
+  GeB    :: Nat ~> Nat ~> Bool
+  And    :: Bool ~> Bool ~> Bool
+  Or     :: Bool ~> Bool ~> Bool
+  Not    :: Bool ~> Bool
+  If     :: Bool ~> a ~> a ~> a
+  Add    :: Nat ~> Nat ~> Nat
+  Sub    :: Nat ~> Nat ~> Nat
+  Mul    :: Nat ~> Nat ~> Nat
+  Exp    :: Nat ~> Nat ~> Nat
+  Div    :: Nat ~> Nat ~> Nat
+  Mod    :: Nat ~> Nat ~> Nat
+  Log2   :: Nat ~> Nat
+  CLog2  :: Nat ~> Nat
+  FLog2  :: Nat ~> Nat
+  Min    :: Nat ~> Nat ~> Nat
+  Max    :: Nat ~> Nat ~> Nat
+  Log    :: Nat ~> Nat ~> Nat
+  FLog   :: Nat ~> Nat ~> Nat
+  CLog   :: Nat ~> Nat ~> Nat
+  CLogWZ :: Nat ~> Nat ~> Nat ~> Nat
+  GCD    :: Nat ~> Nat ~> Nat
+  LCM    :: Nat ~> Nat ~> Nat
 
 deriving stock instance Eq   (a ~> b)
 deriving stock instance Ord  (a ~> b)
@@ -91,11 +92,11 @@ data KnownTypes = KnownTypes
 instance Outputable KnownTypes where
   ppr KnownTypes{..} =
     ("KnownTypes" <+>) $ braces $ ("" <+>) $ (<+> "") $ pprWithCommas id
-      [ ppr ktAssert, ppr ktOrdCond, pOp EqC,  pOp LtC,   pOp LeC,  pOp GtC
-      , pOp GeC, pOp EqB, pOp LtB,   pOp LeB,  pOp GtB,   pOp GeB,  pOp NZero
-      , pOp And, pOp Or,  pOp Not,   pOp If,   pOp Add,   pOp Sub,  pOp Log2
-      , pOp Div, pOp Mod, pOp Mul,   pOp Exp,  pOp Min,   pOp Max,  pOp Log
-      , pOp GCD, pOp LCM, pOp FLog,  pOp CLog, pOp FLog2, pOp CLog2
+      [ ppr ktAssert, ppr ktOrdCond, pOp EqC,  pOp LtC,    pOp LeC,   pOp GtC
+      , pOp GeC, pOp EqB, pOp LtB,   pOp LeB,  pOp GtB,    pOp GeB,   pOp NZero
+      , pOp And, pOp Or,  pOp Not,   pOp If,   pOp Add,    pOp Sub,   pOp Log2
+      , pOp Div, pOp Mod, pOp Mul,   pOp Exp,  pOp Min,    pOp Max,   pOp Log
+      , pOp GCD, pOp LCM, pOp FLog,  pOp CLog, pOp CLogWZ, pOp FLog2, pOp CLog2
       ]
    where
     pOp :: forall a b. (a ~> b) -> SDoc
@@ -142,6 +143,10 @@ instance FromTyCon (Nat ~> Nat ~> Nat) where
         , FLog, CLog, Log, GCD, LCM
         ]
 
+instance FromTyCon (Nat ~> Nat ~> Nat ~> Nat) where
+  fromTyCon KnownTypes{..} = lookupUFM $ listToUFM $ (\x -> (kOp x, x))
+    <$> [ CLogWZ ]
+
 -- | Retrieves the missing 'TyCon's that are not exposed via the GHC API.
 lookupKnownTypes :: TcM KnownTypes
 lookupKnownTypes = do
@@ -171,6 +176,7 @@ lookupKnownTypes = do
   logTyCon     <- lkup ''GHC.TypeLits.Extra.Log
   flogTyCon    <- lkup ''GHC.TypeLits.Extra.FLog
   clogTyCon    <- lkup ''GHC.TypeLits.Extra.CLog
+  clogwzTyCon  <- lkup ''GHC.TypeLits.Extra.CLogWZ
   gcdTyCon     <- lkup ''GHC.TypeLits.Extra.GCD
   lcmTyCon     <- lkup ''GHC.TypeLits.Extra.LCM
   clog2TyCon   <- lkup ''GHC.TypeNats.Proof.CLog2
@@ -178,17 +184,17 @@ lookupKnownTypes = do
   let
     kOp :: forall a b. a ~> b -> TyCon
     kOp = \case
-      Add  -> typeNatAddTyCon  ;  EqC -> eqTyCon   ;  NZero -> nZeroTyCon
-      Sub  -> typeNatSubTyCon  ;  LtC -> ltCTyCon  ;  LCM   -> lcmTyCon
-      Mul  -> typeNatMulTyCon  ;  LeC -> leCTyCon  ;  GCD   -> gcdTyCon
-      Exp  -> typeNatExpTyCon  ;  GtC -> gtCTyCon  ;  CLog  -> clogTyCon
-      Div  -> typeNatDivTyCon  ;  GeC -> geCTyCon  ;  FLog  -> flogTyCon
-      Mod  -> typeNatModTyCon  ;  EqB -> eqBTyCon  ;  CLog2 -> clog2TyCon
-      Log2 -> typeNatLogTyCon  ;  LtB -> ltBTyCon  ;  FLog2 -> flog2TyCon
-      If   -> ifTyCon          ;  LeB -> leBTyCon  ;  Log   -> logTyCon
-      And  -> andTyCon         ;  GtB -> gtBTyCon  ;  Min   -> minTyCon
-      Or   -> orTyCon          ;  GeB -> geBTyCon  ;  Max   -> maxTyCon
-      Not  -> notTyCon
+      Add  -> typeNatAddTyCon  ;  EqC -> eqTyCon   ;  NZero  -> nZeroTyCon
+      Sub  -> typeNatSubTyCon  ;  LtC -> ltCTyCon  ;  LCM    -> lcmTyCon
+      Mul  -> typeNatMulTyCon  ;  LeC -> leCTyCon  ;  GCD    -> gcdTyCon
+      Exp  -> typeNatExpTyCon  ;  GtC -> gtCTyCon  ;  CLog   -> clogTyCon
+      Div  -> typeNatDivTyCon  ;  GeC -> geCTyCon  ;  CLogWZ -> clogwzTyCon
+      Mod  -> typeNatModTyCon  ;  EqB -> eqBTyCon  ;  FLog   -> flogTyCon
+      Log2 -> typeNatLogTyCon  ;  LtB -> ltBTyCon  ;  CLog2  -> clog2TyCon
+      If   -> ifTyCon          ;  LeB -> leBTyCon  ;  FLog2  -> flog2TyCon
+      And  -> andTyCon         ;  GtB -> gtBTyCon  ;  Min    -> minTyCon
+      Or   -> orTyCon          ;  GeB -> geBTyCon  ;  Max    -> maxTyCon
+      Not  -> notTyCon         ;  Log -> logTyCon
 
   return KnownTypes{..}
  where

--- a/src/GHC/TypeNats/Proof/Plugin/Prover/Agda.hs
+++ b/src/GHC/TypeNats/Proof/Plugin/Prover/Agda.hs
@@ -27,32 +27,49 @@ instance (IsString s, Monoid s) => ProverConfig Agda s where
   proverName _ = "Agda"
 
   operatorImports _ = \case
-    EqC   -> "Agda.Builtin.Equality"  ;  And   -> "Data.Bool.Base hiding (_≤_;_<_)"
-    EqB   -> "Agda.Builtin.Equality"  ;  Not   -> "Data.Bool.Base hiding (_≤_;_<_)"
-    NZero -> "Data.Nat.Base"          ;  Or    -> "Data.Bool.Base hiding (_≤_;_<_)"
-    LtC   -> "Data.Nat.Base"          ;  If    -> "Data.Bool.Base hiding (_≤_;_<_)"
-    LeC   -> "Data.Nat.Base"          ;  Log2  -> "Data.Nat.Logarithm"
-    GtC   -> "Data.Nat.Base"          ;  CLog2 -> "Data.Nat.Logarithm"
-    GeC   -> "Data.Nat.Base"          ;  FLog2 -> "Data.Nat.Logarithm"
-    LtB   -> "Data.Nat.Base"          ;  Add   -> "Agda.Builtin.Nat"
-    LeB   -> "Data.Nat.Base"          ;  Sub   -> "Agda.Builtin.Nat"
-    GtB   -> "Data.Nat.Base"          ;  Mul   -> "Agda.Builtin.Nat"
-    GeB   -> "Data.Nat.Base"          ;  GCD   -> "Data.Nat.GCD"
-    Min   -> "Data.Nat.Base"          ;  LCM   -> "Data.Nat.LCM"
-    Max   -> "Data.Nat.Base"          ;  Log   -> ""
-    Exp   -> "Data.Nat.Base"          ;  CLog  -> ""
-    Div   -> "Data.Nat.Base"          ;  FLog  -> ""
-    Mod   -> "Data.Nat.Base"
+    EqC    -> "Agda.Builtin.Equality"
+    EqB    -> "Agda.Builtin.Equality"
+    NZero  -> "Data.Nat.Base"
+    LtC    -> "Data.Nat.Base"
+    LeC    -> "Data.Nat.Base"
+    GtC    -> "Data.Nat.Base"
+    GeC    -> "Data.Nat.Base"
+    LtB    -> "Data.Nat.Base"
+    LeB    -> "Data.Nat.Base"
+    GtB    -> "Data.Nat.Base"
+    GeB    -> "Data.Nat.Base"
+    Min    -> "Data.Nat.Base"
+    Max    -> "Data.Nat.Base"
+    Exp    -> "Data.Nat.Base"
+    Div    -> "Data.Nat.Base"
+    Mod    -> "Data.Nat.Base"
+    And    -> "Data.Bool.Base hiding (_≤_;_<_)"
+    Not    -> "Data.Bool.Base hiding (_≤_;_<_)"
+    Or     -> "Data.Bool.Base hiding (_≤_;_<_)"
+    If     -> "Data.Bool.Base hiding (_≤_;_<_)"
+    Log2   -> "Data.Nat.Logarithm"
+    CLog2  -> "Data.Nat.Logarithm"
+    FLog2  -> "Data.Nat.Logarithm"
+    Add    -> "Agda.Builtin.Nat"
+    Sub    -> "Agda.Builtin.Nat"
+    Mul    -> "Agda.Builtin.Nat"
+    GCD    -> "Data.Nat.GCD"
+    LCM    -> "Data.Nat.LCM"
+    Log    -> ""
+    CLog   -> ""
+    FLog   -> ""
+    CLogWZ -> ""
 
   printOp _ = \case
-    EqB -> "≡ᵇ"  ;  LtB -> "<ᵇ"  ;  LeB -> "≤ᵇ"   ;  GtB    -> ""
-    GeB -> ""    ;  EqC -> "≡"   ;  LtC -> "<"    ;  NZero  -> "NonZero"
-    LeC -> "≤"   ;  GtC -> ">"   ;  GeC -> "≥"    ;  Log2   -> "⌊log₂_⌋"
-    Add -> "+"   ;  Sub -> "-"   ;  Mul -> "*"    ;  CLog2  -> "⌈log₂_⌉"
-    Exp -> "^"   ;  Div -> "/"   ;  Mod -> "%"    ;  FLog2  -> "⌊log₂_⌋"
-    Min -> "⊓"   ;  Max -> "⊔"   ;  GCD -> "gcd"  ;  LCM    -> "lcm"
-    And -> "∧"   ;  Or  -> "∨"   ;  Not -> "not"  ;  If     -> "if_then_else_"
-    Log -> "NO PRIMITIVE"  ;  CLog  -> "NO PRIMITIVE"  ;  FLog -> "NO PRIMITIVE"
+    EqB  -> "≡ᵇ"  ;  LtB -> "<ᵇ"  ;  LeB -> "≤ᵇ"   ;  GtB    -> ""
+    GeB  -> ""    ;  EqC -> "≡"   ;  LtC -> "<"    ;  NZero  -> "NonZero"
+    LeC  -> "≤"   ;  GtC -> ">"   ;  GeC -> "≥"    ;  Log2   -> "⌊log₂_⌋"
+    Add  -> "+"   ;  Sub -> "-"   ;  Mul -> "*"    ;  CLog2  -> "⌈log₂_⌉"
+    Exp  -> "^"   ;  Div -> "/"   ;  Mod -> "%"    ;  FLog2  -> "⌊log₂_⌋"
+    Min  -> "⊓"   ;  Max -> "⊔"   ;  GCD -> "gcd"  ;  LCM    -> "lcm"
+    And  -> "∧"   ;  Or  -> "∨"   ;  Not -> "not"  ;  If     -> "if_then_else_"
+    Log  -> "NO PRIMITIVE"  ;  CLog   -> "NO PRIMITIVE"
+    FLog -> "NO PRIMITIVE"  ;  CLogWZ -> "NO PRIMITIVE"
 
   printBool _ = \case
     True  -> "true"
@@ -107,16 +124,17 @@ instance (IsString s, Monoid s) => ProverConfig Agda s where
 
 instance ProverFixities Agda where
   bOpFixity _ = \case
-    EqB -> Fixity 4 InfixN Infix   ;  LtB  -> Fixity 4 InfixN Infix
-    LeB -> Fixity 4 InfixN Infix   ;  GtB  -> Fixity 4 InfixN Infix
-    GeB -> Fixity 4 InfixN Infix   ;  EqC  -> Fixity 4 InfixN Infix
-    LtC -> Fixity 4 InfixN Infix   ;  LeC  -> Fixity 4 InfixN Infix
-    GtC -> Fixity 4 InfixN Infix   ;  GeC  -> Fixity 4 InfixN Infix
-    And -> Fixity 6 InfixR Infix   ;  Or   -> Fixity 5 InfixR Infix
-    If  -> Fixity 0 InfixN Prefix  ;  Add  -> Fixity 6 InfixL Infix
-    Sub -> Fixity 6 InfixL Infix   ;  Mul  -> Fixity 7 InfixL Infix
-    Exp -> Fixity 8 InfixR Infix   ;  Div  -> Fixity 7 InfixL Infix
-    Mod -> Fixity 7 InfixL Infix   ;  Min  -> Fixity 7 InfixL Infix
-    Max -> Fixity 6 InfixL Infix   ;  FLog -> Fixity 9 InfixL Prefix
-    Log -> Fixity 9 InfixL Prefix  ;  CLog -> Fixity 9 InfixL Prefix
-    GCD -> Fixity 9 InfixL Prefix  ;  LCM  -> Fixity 9 InfixL Prefix
+    EqB -> Fixity 4 InfixN Infix   ;  LtB    -> Fixity 4 InfixN Infix
+    LeB -> Fixity 4 InfixN Infix   ;  GtB    -> Fixity 4 InfixN Infix
+    GeB -> Fixity 4 InfixN Infix   ;  EqC    -> Fixity 4 InfixN Infix
+    LtC -> Fixity 4 InfixN Infix   ;  LeC    -> Fixity 4 InfixN Infix
+    GtC -> Fixity 4 InfixN Infix   ;  GeC    -> Fixity 4 InfixN Infix
+    And -> Fixity 6 InfixR Infix   ;  Or     -> Fixity 5 InfixR Infix
+    If  -> Fixity 0 InfixN Prefix  ;  Add    -> Fixity 6 InfixL Infix
+    Sub -> Fixity 6 InfixL Infix   ;  Mul    -> Fixity 7 InfixL Infix
+    Exp -> Fixity 8 InfixR Infix   ;  Div    -> Fixity 7 InfixL Infix
+    Mod -> Fixity 7 InfixL Infix   ;  Min    -> Fixity 7 InfixL Infix
+    Max -> Fixity 6 InfixL Infix   ;  FLog   -> Fixity 9 InfixL Prefix
+    Log -> Fixity 9 InfixL Prefix  ;  CLog   -> Fixity 9 InfixL Prefix
+    GCD -> Fixity 9 InfixL Prefix  ;  CLogWZ -> Fixity 9 InfixL Prefix
+    LCM -> Fixity 9 InfixL Prefix

--- a/src/GHC/TypeNats/Proof/Plugin/Prover/Coq.hs
+++ b/src/GHC/TypeNats/Proof/Plugin/Prover/Coq.hs
@@ -28,35 +28,36 @@ instance (IsString s, Monoid s) => ProverConfig Coq s where
   proverName _ = "Coq"
 
   operatorImports _ = \case
-    NZero -> "Coq.Init.Logic"  ;  Add   -> "Coq.Init.Nat"
-    EqC   -> "Coq.Init.Logic"  ;  Sub   -> "Coq.Init.Nat"
-    LtC   -> "Coq.Init.Logic"  ;  Mul   -> "Coq.Init.Nat"
-    LeC   -> "Coq.Init.Logic"  ;  Exp   -> "Coq.Init.Nat"
-    GtC   -> "Coq.Init.Logic"  ;  Div   -> "Coq.Init.Nat"
-    GeC   -> "Coq.Init.Logic"  ;  Mod   -> "Coq.Init.Nat"
-    EqB   -> ""                ;  Min   -> "Coq.Init.Nat"
-    LtB   -> "Coq.Init.Nat"    ;  Max   -> "Coq.Init.Nat"
-    LeB   -> "Coq.Init.Nat"    ;  Log2  -> "Coq.Init.Nat"
-    GtB   -> "Coq.Init.Nat"    ;  CLog2 -> "Coq.Init.Nat"
-    GeB   -> "Coq.Init.Nat"    ;  GCD   -> "Coq.Init.Nat"
-    And   -> "Bool"            ;  LCM   -> "Coq.Init.Nat"
-    Or    -> "Bool"            ;  FLog2 -> ""
-    Not   -> "Bool"            ;  Log   -> ""
-    If    -> ""                ;  CLog  -> ""
-    FLog  -> ""
+    NZero -> "Coq.Init.Logic"  ;  Add    -> "Coq.Init.Nat"
+    EqC   -> "Coq.Init.Logic"  ;  Sub    -> "Coq.Init.Nat"
+    LtC   -> "Coq.Init.Logic"  ;  Mul    -> "Coq.Init.Nat"
+    LeC   -> "Coq.Init.Logic"  ;  Exp    -> "Coq.Init.Nat"
+    GtC   -> "Coq.Init.Logic"  ;  Div    -> "Coq.Init.Nat"
+    GeC   -> "Coq.Init.Logic"  ;  Mod    -> "Coq.Init.Nat"
+    EqB   -> ""                ;  Min    -> "Coq.Init.Nat"
+    LtB   -> "Coq.Init.Nat"    ;  Max    -> "Coq.Init.Nat"
+    LeB   -> "Coq.Init.Nat"    ;  Log2   -> "Coq.Init.Nat"
+    GtB   -> "Coq.Init.Nat"    ;  CLog2  -> "Coq.Init.Nat"
+    GeB   -> "Coq.Init.Nat"    ;  GCD    -> "Coq.Init.Nat"
+    And   -> "Bool"            ;  LCM    -> "Coq.Init.Nat"
+    Or    -> "Bool"            ;  FLog2  -> ""
+    Not   -> "Bool"            ;  Log    -> ""
+    If    -> ""                ;  CLog   -> ""
+    FLog  -> ""                ;  CLogWZ -> ""
 
   printOp _ = \case
-    EqB   -> "=?"   ;  LtB -> "<?"    ;  LeB   -> "<=?"
-    GtB   -> ""     ;  GeB -> ""      ;  NZero -> "1 <="
-    EqC   -> "="    ;  LtC -> "<"     ;  LeC   -> "<="
-    GtC   -> ">"    ;  GeC -> ">="    ;  And   -> "&&"
-    Or    -> "||"   ;  Not -> "negb"  ;  If    -> "if"
-    Add   -> "+"    ;  Sub -> "-"     ;  Log2  -> "log2"
-    Mul   -> "*"    ;  Exp -> "^"     ;  FLog2 -> "log2"
-    Div   -> "/"    ;  Mod -> "mod"   ;  Min   -> "min"
-    Max   -> "max"  ;  GCD -> "gcd"   ;  LCM   -> "Nat.lcm"
-    CLog  -> "NO PRIMITIVE"  ;  FLog -> "NO PRIMITIVE"
-    CLog2 -> "NO PRIMITIVE"  ;  Log  -> "NO PRIMITIVE"
+    EqB    -> "=?"   ;  LtB -> "<?"    ;  LeB   -> "<=?"
+    GtB    -> ""     ;  GeB -> ""      ;  NZero -> "1 <="
+    EqC    -> "="    ;  LtC -> "<"     ;  LeC   -> "<="
+    GtC    -> ">"    ;  GeC -> ">="    ;  And   -> "&&"
+    Or     -> "||"   ;  Not -> "negb"  ;  If    -> "if"
+    Add    -> "+"    ;  Sub -> "-"     ;  Log2  -> "log2"
+    Mul    -> "*"    ;  Exp -> "^"     ;  FLog2 -> "log2"
+    Div    -> "/"    ;  Mod -> "mod"   ;  Min   -> "min"
+    Max    -> "max"  ;  GCD -> "gcd"   ;  LCM   -> "Nat.lcm"
+    CLog   -> "NO PRIMITIVE"  ;  FLog -> "NO PRIMITIVE"
+    CLog2  -> "NO PRIMITIVE"  ;  Log  -> "NO PRIMITIVE"
+    CLogWZ -> "NO PRIMITIVE"
 
   printBool _ = \case
     True  -> "true"
@@ -121,16 +122,17 @@ instance (IsString s, Monoid s) => ProverConfig Coq s where
 
 instance ProverFixities Coq where
   bOpFixity _ = \case
-    EqB -> Fixity 4 InfixN Infix   ;  LtB  -> Fixity 4 InfixN Infix
-    LeB -> Fixity 4 InfixN Infix   ;  GtB  -> Fixity 4 InfixN Infix
-    GeB -> Fixity 4 InfixN Infix   ;  EqC  -> Fixity 4 InfixN Infix
-    LtC -> Fixity 4 InfixN Infix   ;  LeC  -> Fixity 4 InfixN Infix
-    GtC -> Fixity 4 InfixN Infix   ;  GeC  -> Fixity 4 InfixN Infix
-    And -> Fixity 6 InfixR Infix   ;  Or   -> Fixity 5 InfixR Infix
-    If  -> Fixity 0 InfixN Prefix  ;  Add  -> Fixity 6 InfixL Infix
-    Sub -> Fixity 6 InfixL Infix   ;  Mul  -> Fixity 7 InfixL Infix
-    Exp -> Fixity 8 InfixL Infix   ;  Div  -> Fixity 7 InfixL Infix
-    Mod -> Fixity 7 InfixL Infix   ;  Min  -> Fixity 9 InfixL Prefix
-    Max -> Fixity 9 InfixL Prefix  ;  FLog -> Fixity 9 InfixL Prefix
-    Log -> Fixity 9 InfixL Prefix  ;  CLog -> Fixity 9 InfixL Prefix
-    GCD -> Fixity 9 InfixL Prefix  ;  LCM  -> Fixity 9 InfixL Prefix
+    EqB -> Fixity 4 InfixN Infix   ;  LtB    -> Fixity 4 InfixN Infix
+    LeB -> Fixity 4 InfixN Infix   ;  GtB    -> Fixity 4 InfixN Infix
+    GeB -> Fixity 4 InfixN Infix   ;  EqC    -> Fixity 4 InfixN Infix
+    LtC -> Fixity 4 InfixN Infix   ;  LeC    -> Fixity 4 InfixN Infix
+    GtC -> Fixity 4 InfixN Infix   ;  GeC    -> Fixity 4 InfixN Infix
+    And -> Fixity 6 InfixR Infix   ;  Or     -> Fixity 5 InfixR Infix
+    If  -> Fixity 0 InfixN Prefix  ;  Add    -> Fixity 6 InfixL Infix
+    Sub -> Fixity 6 InfixL Infix   ;  Mul    -> Fixity 7 InfixL Infix
+    Exp -> Fixity 8 InfixL Infix   ;  Div    -> Fixity 7 InfixL Infix
+    Mod -> Fixity 7 InfixL Infix   ;  Min    -> Fixity 9 InfixL Prefix
+    Max -> Fixity 9 InfixL Prefix  ;  FLog   -> Fixity 9 InfixL Prefix
+    Log -> Fixity 9 InfixL Prefix  ;  CLog   -> Fixity 9 InfixL Prefix
+    GCD -> Fixity 9 InfixL Prefix  ;  CLogWZ -> Fixity 9 InfixL Prefix
+    LCM -> Fixity 9 InfixL Prefix

--- a/src/GHC/TypeNats/Proof/Plugin/Prover/Lean.hs
+++ b/src/GHC/TypeNats/Proof/Plugin/Prover/Lean.hs
@@ -37,6 +37,7 @@ instance (IsString s, Monoid s) => ProverConfig Lean s where
     Not   -> ""  ;  Log   -> "Mathlib.Data.Nat.Log"
     If    -> ""  ;  CLog  -> "Mathlib.Data.Nat.Log"
     FLog  -> "Mathlib.Data.Nat.Log"
+    CLogWZ -> "NO PRIMITIVE"
 
   printBool _ = \case
     True  -> "true"
@@ -52,6 +53,7 @@ instance (IsString s, Monoid s) => ProverConfig Lean s where
     Log2  -> "Nat.log2"  ;  FLog2 -> "Nat.log2"  ;  CLog2 -> "Nat.clog 2"
     Mod   -> "%"         ;  GCD   -> "Nat.gcd"   ;  LCM   -> "Nat.lcm"
     NZero -> "0 ≠"       ;  Min   -> "min"       ;  Max   -> "max"
+    CLogWZ -> "NO PRIMITIVE"
 
   printTerm p = \case
     Op If `S` t0 `S` t1 `S` t2 ->
@@ -120,16 +122,17 @@ instance ProverFixities Lean where
   -- being a ternary operator, is always parenthesized anyway.
 
   bOpFixity _ = \case
-    EqB  -> Fixity 50   InfixN Infix   ;  LtB  -> Fixity 90   InfixL Prefix
-    LeB  -> Fixity 90   InfixL Prefix  ;  GtB  -> Fixity 90   InfixL Prefix
-    GeB  -> Fixity 90   InfixL Prefix  ;  EqC  -> Fixity 50   InfixN Infix
-    LtC  -> Fixity 50   InfixN Infix   ;  LeC  -> Fixity 50   InfixN Infix
-    GtC  -> Fixity 50   InfixN Infix   ;  GeC  -> Fixity 50   InfixN Infix
-    And  -> Fixity 35   InfixL Infix   ;  Or   -> Fixity 30   InfixL Infix
-    If   -> Fixity 1022 InfixL Prefix  ;  Add  -> Fixity 65   InfixL Infix
-    Sub  -> Fixity 65   InfixL Infix   ;  Mul  -> Fixity 70   InfixL Infix
-    Exp  -> Fixity 80   InfixR Infix   ;  Div  -> Fixity 70   InfixL Infix
-    Mod  -> Fixity 70   InfixL Infix   ;  Min  -> Fixity 90   InfixL Prefix
-    Max  -> Fixity 90   InfixL Prefix  ;  FLog -> Fixity 90   InfixL Prefix
-    Log  -> Fixity 90   InfixL Prefix  ;  CLog -> Fixity 90   InfixL Prefix
-    GCD  -> Fixity 90   InfixL Prefix  ;  LCM  -> Fixity 90   InfixL Prefix
+    EqB  -> Fixity 50   InfixN Infix   ;  LtB    -> Fixity 90 InfixL Prefix
+    LeB  -> Fixity 90   InfixL Prefix  ;  GtB    -> Fixity 90 InfixL Prefix
+    GeB  -> Fixity 90   InfixL Prefix  ;  EqC    -> Fixity 50 InfixN Infix
+    LtC  -> Fixity 50   InfixN Infix   ;  LeC    -> Fixity 50 InfixN Infix
+    GtC  -> Fixity 50   InfixN Infix   ;  GeC    -> Fixity 50 InfixN Infix
+    And  -> Fixity 35   InfixL Infix   ;  Or     -> Fixity 30 InfixL Infix
+    If   -> Fixity 1022 InfixL Prefix  ;  Add    -> Fixity 65 InfixL Infix
+    Sub  -> Fixity 65   InfixL Infix   ;  Mul    -> Fixity 70 InfixL Infix
+    Exp  -> Fixity 80   InfixR Infix   ;  Div    -> Fixity 70 InfixL Infix
+    Mod  -> Fixity 70   InfixL Infix   ;  Min    -> Fixity 90 InfixL Prefix
+    Max  -> Fixity 90   InfixL Prefix  ;  FLog   -> Fixity 90 InfixL Prefix
+    Log  -> Fixity 90   InfixL Prefix  ;  CLog   -> Fixity 90 InfixL Prefix
+    GCD  -> Fixity 90   InfixL Prefix  ;  CLogWZ -> Fixity 90 InfixL Prefix
+    LCM  -> Fixity 90   InfixL Prefix

--- a/src/GHC/TypeNats/Proof/Plugin/Prover/Tynal.hs
+++ b/src/GHC/TypeNats/Proof/Plugin/Prover/Tynal.hs
@@ -82,14 +82,14 @@ instance Outputable (Term a) where
    where
     pprOp :: (b ~> c) -> SDoc
     pprOp = \case
-      NZero -> "(1 <=)"  ;  EqC  -> "(~)"   ;  LtC -> "(<)"    ;  LeC -> "(<=)"
-      GtC   -> "(>)"     ;  GeC  -> "(>=)"  ;  EqB -> "(==)"   ;  LtB -> "(<?)"
-      LeB   -> "(<=?)"   ;  GtB  -> "(>?)"  ;  GeB -> "(>=?)"  ;  And -> "(&&)"
-      Or    -> "(||)"    ;  Not  -> "Not"   ;  If  -> "If"     ;  Add -> "(+)"
-      Sub   -> "(-)"     ;  Mul  -> "(*)"   ;  Exp -> "(^)"    ;  Div -> "(/)"
-      Mod   -> "Mod"     ;  Log2 -> "Log2"  ;  Min -> "Min"    ;  Max -> "Max"
-      CLog2 -> "CLog2"   ;  FLog -> "FLog"  ;  GCD -> "GCD"    ;  LCM -> "LCM"
-      FLog2 -> "FLog2"   ;  CLog -> "CLog"  ;  Log -> "Log"
+      NZero  -> "(1 <=)"  ;  EqC  -> "(~)"   ;  LtC -> "(<)"    ;  LeC -> "(<=)"
+      GtC    -> "(>)"     ;  GeC  -> "(>=)"  ;  EqB -> "(==)"   ;  LtB -> "(<?)"
+      LeB    -> "(<=?)"   ;  GtB  -> "(>?)"  ;  GeB -> "(>=?)"  ;  And -> "(&&)"
+      Or     -> "(||)"    ;  Not  -> "Not"   ;  If  -> "If"     ;  Add -> "(+)"
+      Sub    -> "(-)"     ;  Mul  -> "(*)"   ;  Exp -> "(^)"    ;  Div -> "(/)"
+      CLogWZ -> "CLogWZ"  ;  Log2 -> "Log2"  ;  Log -> "Log"    ;  Mod -> "Mod"
+      CLog2  -> "CLog2"   ;  FLog -> "FLog"  ;  GCD -> "GCD"    ;  LCM -> "LCM"
+      FLog2  -> "FLog2"   ;  CLog -> "CLog"  ;  Min -> "Min"    ;  Max -> "Max"
 
 -- | A generalized interface for signatures of a type level proof.
 data Signature a = Signature
@@ -261,6 +261,12 @@ instance FromType (Term Nat) where
       -> do ty0' <- fromType kt ty0
             ty1' <- fromType kt ty1
             return $ Op op `S` ty0' `S` ty1'
+    TyConApp tc [ty0, ty1, ty2]
+      | Just (op :: Nat ~> Nat ~> Nat ~> Nat) <- fromTyCon kt tc
+      -> do ty0' <- fromType kt ty0
+            ty1' <- fromType kt ty1
+            ty2' <- fromType kt ty2
+            return $ Op op `S` ty0' `S` ty1' `S` ty2'
     TyConApp tc tys
       | Just (op :: Bool ~> Nat ~> Nat ~> Nat) <- fromTyCon kt tc
       , [ty0, ty1, ty2] <- dropTKTypes tys
@@ -334,6 +340,11 @@ specializeTerm = \case
   Op LeC  `S` (Lit 1) `S` t -> Op NZero `S` specializeTerm t
   Op CLog `S` (Lit 2) `S` t -> Op CLog2 `S` specializeTerm t
   Op FLog `S` (Lit 2) `S` t -> Op FLog2 `S` specializeTerm t
+  Op CLogWZ `S` t0 `S` t1 `S` t2 ->
+    let a = Op CLog `S` t0 `S` t1
+        c = Op EqB `S` t1 `S` Lit 0
+        t = Op If `S` c `S` t2 `S` a
+     in specializeTerm t
   Op op `S` t -> Op op `S` specializeTerm t
   t0 `S` t1 -> specializeTerm t0 `S` specializeTerm t1
   x -> x

--- a/tests/Test/GHC/TypeNats/Proof/Plugin/Agda.hs
+++ b/tests/Test/GHC/TypeNats/Proof/Plugin/Agda.hs
@@ -170,3 +170,24 @@ class
 T15 (suc _) = refl
 /-}
 instance T15 n => QED (T15 n)
+
+instance
+  ( 2 <= n
+  ) => T16 n
+class
+  ( 1 <= CLogWZ 2 n 0
+  ) => T16 n
+{-/ Proof (Agda): T16
+open import Relation.Nullary.Negation.Core using (contradiction)
+open import Data.Nat.Properties using (m+1+n≰m; ≤-trans; n≤1+n)
+T16 (suc n) 2≤n = >-nonZero (lemma (suc n) 2≤n)
+ where
+  lemma : (n : ℕ) → 2 ≤ n → 1 ≤ ⌈log₂_⌉ n
+  lemma (suc zero) 2≤n = contradiction (s≤s⁻¹ 2≤n) (m+1+n≰m 0)
+  lemma (suc (suc zero)) 2≤n = s≤s z≤n
+  lemma (suc (suc (suc n))) 2≤n =
+    ≤-trans
+      (lemma (suc (suc n)) (s≤s (s≤s z≤n)))
+      (⌈log₂⌉-mono-≤ (n≤1+n ((suc (suc n)))))
+/-}
+instance T16 n => QED (T16 n)

--- a/tests/Test/GHC/TypeNats/Proof/Plugin/Lean.hs
+++ b/tests/Test/GHC/TypeNats/Proof/Plugin/Lean.hs
@@ -196,3 +196,17 @@ class
   simp [Nat.zero_mod]
 /-}
 instance T16 n => QED (T16 n)
+
+instance T17 n
+class
+  ( CLogWZ 2 (2 ^ n) 0 ~ n
+  ) => T17 n
+{-/ Proof (Lean): T17
+  cases n with
+  | zero => simp
+  | succ n =>
+      have rule : (2 ^ (n + 1) == 0) = false := by simp
+      rw [rule]
+      exact Nat.clog_pow 2 (n + 1) (hb := by decide)
+/-}
+instance T17 n => QED (T17 n)


### PR DESCRIPTION
The PR adds support for the [`CLogWZ`](https://hackage-content.haskell.org/package/ghc-typelits-extra-0.5.2/docs/GHC-TypeLits-Extra.html#t:CLogWZ) type family, as introduced by `ghc-typelits-extra-0.5.2`.

---

Approved for public release. This work has been supported by funding from the _Agentur für Innovation in der Cybersicherheit GmbH ([Cyberagentur](https://www.cyberagentur.de))_ as part of the [Clash Formal](https://clash-formal.org) project.
